### PR TITLE
[EXP-1816] Add profile to deploy output

### DIFF
--- a/build/continuous-deploy-fingerprint/index.js
+++ b/build/continuous-deploy-fingerprint/index.js
@@ -44675,6 +44675,8 @@ async function continuousDeployFingerprintAction(input = collectContinuousDeploy
         (0, core_1.setOutput)('ios-build-id', newIosBuildInfo.id);
     if (updates?.length)
         (0, core_1.setOutput)('update-output', updates);
+    if (input.profile)
+        (0, core_1.setOutput)('profile', input.profile);
 }
 exports.continuousDeployFingerprintAction = continuousDeployFingerprintAction;
 async function getFingerprintHashForPlatformAsync({ cwd, platform, }) {

--- a/src/actions/continuous-deploy-fingerprint.ts
+++ b/src/actions/continuous-deploy-fingerprint.ts
@@ -170,6 +170,7 @@ export async function continuousDeployFingerprintAction(input = collectContinuou
   if (newAndroidBuildInfo?.id) setOutput('android-build-id', newAndroidBuildInfo.id);
   if (newIosBuildInfo?.id) setOutput('ios-build-id', newIosBuildInfo.id);
   if (updates?.length) setOutput('update-output', updates);
+  if (input.profile) setOutput('profile', input.profile);
 }
 
 async function getFingerprintHashForPlatformAsync({


### PR DESCRIPTION
### Linked issue
https://linear.app/centerid/issue/EXP-1816

### Additional context
Adds a new deploy output for profile to use in PR workflow to check builds against development and development-simulator
